### PR TITLE
truncate reads the claimed DB via DreamApp#testDatabaseName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.0
+
+- `truncate` now resolves the database to clear via `DreamApp#testDatabaseName` (the single source of truth for the per-live-worker test-database pool introduced in `@rvoh/dream@2.14.0`) instead of recomputing `<base>_<VITEST_POOL_ID>` on its own. `truncate` opens its own `pg.Client`, so it has to read — and, on first use, trigger — the same advisory-lock claim Dream's connection resolution uses; otherwise it would truncate a different database than the one the worker writes to. Falls back to the legacy `VITEST_POOL_ID`-based name when running against a Dream older than 2.14.0 (which lacks `testDatabaseName`), so this release is safe to adopt ahead of upgrading Dream.
+
 ## 2.1.1
 
 - `toEqualClockTimeTz` matcher

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@rvoh/dream-spec-helpers",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "dream orm spec helpers",
   "author": "RVO Health",
   "repository": {

--- a/src/truncate.ts
+++ b/src/truncate.ts
@@ -30,7 +30,11 @@ export default async function truncate(
   const client = new pg.Client({
     host: credentials.host || "localhost",
     port: credentials.port,
-    database: getDatabaseName(dreamconf, credentials.name),
+    database: await resolveDatabaseName(
+      dreamconf,
+      connectionName,
+      credentials.name,
+    ),
     user: credentials.user,
     password: credentials.password,
   })
@@ -56,7 +60,26 @@ $$;
   await client.end()
 }
 
-function getDatabaseName(dreamconf: any, dbName: string): string {
+// Resolve the database `truncate` should connect to. As of @rvoh/dream's
+// per-live-worker test-database pool, the worker claims a database via a
+// Postgres advisory lock and `dreamconf.testDatabaseName` is the single source
+// of truth for the claimed name — `truncate` opens its own `pg.Client`, so it
+// must read (and, if needed, trigger) that claim rather than recomputing a
+// name from VITEST_POOL_ID, which is a reusable slot id that overlapping
+// workers share. Older dream versions lack `testDatabaseName`; for those we
+// fall back to the legacy VITEST_POOL_ID-based name.
+async function resolveDatabaseName(
+  dreamconf: any,
+  connectionName: string,
+  dbName: string,
+): Promise<string> {
+  if (typeof dreamconf.testDatabaseName === "function") {
+    return await dreamconf.testDatabaseName(connectionName, "primary")
+  }
+  return legacyDatabaseName(dreamconf, dbName)
+}
+
+function legacyDatabaseName(dreamconf: any, dbName: string): string {
   return parallelDatabasesEnabled(dreamconf)
     ? `${dbName}_${process.env.VITEST_POOL_ID}`
     : dbName


### PR DESCRIPTION
## What

`truncate` now resolves the database it clears via **`DreamApp#testDatabaseName`** — the single source of truth for the per-live-worker test-database pool introduced in **`@rvoh/dream@2.14.0`** — instead of recomputing `<base>_<VITEST_POOL_ID>` itself.

## Why

`@rvoh/dream@2.14.0` stops keying the test database off vitest's reusable `VITEST_POOL_ID` slot (which overlapping worker processes share) and instead has each live worker **claim** its own database from a pre-created pool via a Postgres advisory lock. `truncate` opens its **own** `pg.Client`, so if it kept recomputing the name from `VITEST_POOL_ID` it would clear a *different* database than the one the worker actually reads and writes — data would accumulate in the write DB (duplicate-key / FK errors) and tests would 404 on records that were never truncated. Reading the claimed name via `testDatabaseName` keeps `truncate` and Dream's connection resolution pointed at the same database, and triggers the claim on first use if it hasn't happened yet.

## Compatibility

Falls back to the legacy `VITEST_POOL_ID`-based name when running against a Dream older than 2.14.0 (which has no `testDatabaseName`), so this release is safe to adopt **before** upgrading Dream.

## Release ordering

This package (`2.2.0`) should be published **first**; `@rvoh/dream@2.14.0` depends on it for its own test suite.

## Verification

Exercised as part of `@rvoh/dream`'s own `pnpm spec` (built and linked locally): 4 full runs green (3162 passed, 0 failed), where the old `VITEST_POOL_ID` truncate produced 331–389 failures per run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)