### PR TITLE
fix: upgrade to pnpm 11.9.0, add pnpm-workspace.yaml with strictDepBuilds and esbuild blocked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.2
+
+- upgrade to pnpm@11.9.0; add pnpm-workspace.yaml with strictDepBuilds: false and esbuild blocked
+
 ## 2.2.1
 
 - switch to Github action publishing to npmjs.com

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@rvoh/dream-spec-helpers",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "dream orm spec helpers",
   "author": "RVO Health",
   "publishConfig": {
@@ -50,7 +50,7 @@
     "typescript-eslint": "^8.48.1",
     "vitest": "^4.0.10"
   },
-  "packageManager": "pnpm@10.24.0+sha512.01ff8ae71b4419903b65c60fb2dc9d34cf8bb6e06d03bde112ef38f7a34d6904c424ba66bea5cdcf12890230bf39f9580473140ed9c946fef328b6e5238a345a",
+  "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b",
   "dependencies": {
     "commander": "^14.0.2",
     "dotenv": "^17.2.3",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,13 @@
+# SECURITY — allowBuilds is a supply-chain allowlist. pnpm 10+ blocks ALL
+# dependency lifecycle scripts (postinstall, etc.) by default; that default is
+# the primary defense against Shai-Hulud-class npm worms. Only packages listed
+# below (= true) may run install/build scripts. Keep this MINIMAL — every entry
+# re-opens script execution for that package, so add one only with clear cause.
+# esbuild ships prebuilt platform binaries via optionalDependencies and does not
+# need its postinstall to run; it is listed here (= false / blocked) so pnpm 11
+# does not rewrite this file with placeholder prompts on every non-interactive
+# install (pnpm/pnpm#11574).
+strictDepBuilds: false
+
+allowBuilds:
+  esbuild: false


### PR DESCRIPTION
## Summary

- Upgrades `packageManager` from `pnpm@10.24.0` to `pnpm@11.9.0`
- Adds `pnpm-workspace.yaml` with `strictDepBuilds: false` to suppress the pnpm 11 hard-error on build-script deps that aren't explicitly declared
- Blocks `esbuild` in `allowBuilds` (set to `false`) so pnpm 11 doesn't rewrite the workspace file with placeholder prompts on every non-interactive install ([pnpm/pnpm#11574](https://github.com/pnpm/pnpm/issues/11574))
- Bumps package version `2.2.1` → `2.2.2`

## Test plan

- [ ] `pnpm install` completes without errors on pnpm 11.9.0
- [ ] No unexpected build script execution warnings
- [ ] Package builds and publishes as usual

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GhY4PpeeQcHTxS2kZr1n8x